### PR TITLE
(GH-163) Throw ArgumentNullException instead of NullReferenceException

### DIFF
--- a/src/Cake.AzureDevOps.Tests/PullRequest/AzureDevOpsPullRequestTests.cs
+++ b/src/Cake.AzureDevOps.Tests/PullRequest/AzureDevOpsPullRequestTests.cs
@@ -841,7 +841,7 @@
                 var result = Record.Exception(() => pullRequest.CreateCommentThread(null));
 
                 // Then
-                Assert.IsType<NullReferenceException>(result);
+                result.IsArgumentNullException("thread");
             }
 
             [Fact]

--- a/src/Cake.AzureDevOps/PullRequest/AzureDevOpsPullRequest.cs
+++ b/src/Cake.AzureDevOps/PullRequest/AzureDevOpsPullRequest.cs
@@ -574,6 +574,8 @@
         /// <param name="thread">The instance of the thread.</param>
         public void CreateCommentThread(AzureDevOpsPullRequestCommentThread thread)
         {
+            thread.NotNull(nameof(thread));
+
             if (!this.ValidatePullRequest())
             {
                 return;


### PR DESCRIPTION
Throw ArgumentNullException instead of NullReferenceException

Fixes #163 