### PR TITLE
(GH-191) Fix NuGet packaging

### DIFF
--- a/src/Cake.AzureDevOps/Cake.AzureDevOps.csproj
+++ b/src/Cake.AzureDevOps/Cake.AzureDevOps.csproj
@@ -69,7 +69,7 @@
       <TfmSpecificPackageFile Include="$(OutputPath)\**\Microsoft.TeamFoundation.Core.WebApi.dll">
         <PackagePath>lib\$(TargetFramework)\</PackagePath>
       </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\**\Microsoft.TeamFoundation.DistributedTask.Common.Contracts">
+      <TfmSpecificPackageFile Include="$(OutputPath)\**\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll">
         <PackagePath>lib\$(TargetFramework)\</PackagePath>
       </TfmSpecificPackageFile>
       <TfmSpecificPackageFile Include="$(OutputPath)\**\Microsoft.TeamFoundation.SourceControl.WebApi.dll">


### PR DESCRIPTION
Add missing `Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll` to NuGet package.

Fixes #191 