### PR TITLE
Add overload for UsingAzurePipelinesOAuthToken accepting a build id

### DIFF
--- a/src/Cake.AzureDevOps.Tests/Pipelines/AzureDevOpsBuildSettingsTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Pipelines/AzureDevOpsBuildSettingsTests.cs
@@ -840,6 +840,40 @@
             }
 
             [Fact]
+            public void Should_Throw_If_Build_Id_Env_Var_Is_Set_But_Ctor_Build_Id_Value_Zero()
+            {
+                // Given
+                var creds = new AzureDevOpsNtlmCredentials();
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "MyProject");
+                Environment.SetEnvironmentVariable("BUILD_BUILDID", "20");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => new AzureDevOpsBuildSettings(0, creds));
+
+                // Then
+                result.IsArgumentOutOfRangeException("buildId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Build_Id_Env_Var_Is_Set_But_Ctor_Build_Id_Value_Negative()
+            {
+                // Given
+                var creds = new AzureDevOpsNtlmCredentials();
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "MyProject");
+                Environment.SetEnvironmentVariable("BUILD_BUILDID", "20");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => new AzureDevOpsBuildSettings(-1, creds));
+
+                // Then
+                result.IsArgumentOutOfRangeException("buildId");
+            }
+
+            [Fact]
             public void Should_Throw_If_Build_Id_Env_Var_Is_Not_Integer()
             {
                 // Given
@@ -874,7 +908,7 @@
             }
 
             [Fact]
-            public void Should_Throw_If_System_Access_Token_Env_Var_Is_Not_Set()
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_Not_Set_With_OAuthToken()
             {
                 // Given
                 Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
@@ -890,7 +924,7 @@
             }
 
             [Fact]
-            public void Should_Throw_If_System_Access_Token_Env_Var_Is_Empty()
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_Empty_With_OAuthToken()
             {
                 // Given
                 Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
@@ -906,7 +940,7 @@
             }
 
             [Fact]
-            public void Should_Throw_If_System_Access_Token_Env_Var_Is_WhiteSpace()
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_WhiteSpace_With_OAuthToken()
             {
                 // Given
                 Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
@@ -916,6 +950,88 @@
 
                 // When
                 var result = Record.Exception(() => AzureDevOpsBuildSettings.UsingAzurePipelinesOAuthToken());
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_Not_Set_And_Correct_Build_Id()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "MyProject");
+                Environment.SetEnvironmentVariable("BUILD_BUILDID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", null);
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsBuildSettings.UsingAzurePipelinesOAuthToken(42));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_Empty_And_Correct_Build_Id_With_OAuthToken()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "MyProject");
+                Environment.SetEnvironmentVariable("BUILD_BUILDID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", string.Empty);
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsBuildSettings.UsingAzurePipelinesOAuthToken(42));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Build_Id_Env_Var_Is_Set_But_Ctor_Build_Id_Value_Zero_With_OAuthToken()
+            {
+                // Given
+                var creds = new AzureDevOpsNtlmCredentials();
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "MyProject");
+                Environment.SetEnvironmentVariable("BUILD_BUILDID", "20");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsBuildSettings.UsingAzurePipelinesOAuthToken(0));
+
+                // Then
+                result.IsArgumentOutOfRangeException("buildId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Build_Id_Env_Var_Is_Set_But_Ctor_Build_Id_Value_Negative_With_OAuthToken()
+            {
+                // Given
+                var creds = new AzureDevOpsNtlmCredentials();
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "MyProject");
+                Environment.SetEnvironmentVariable("BUILD_BUILDID", "20");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsBuildSettings.UsingAzurePipelinesOAuthToken(-1));
+
+                // Then
+                result.IsArgumentOutOfRangeException("buildId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_WhiteSpace_And_Correct_Build_Id_With_OAuthToken()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "MyProject");
+                Environment.SetEnvironmentVariable("BUILD_BUILDID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", " ");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsBuildSettings.UsingAzurePipelinesOAuthToken(42));
 
                 // Then
                 result.IsInvalidOperationException();
@@ -969,6 +1085,24 @@
 
                 // When
                 var settings = new AzureDevOpsBuildSettings(creds);
+
+                // Then
+                settings.BuildId.ShouldBe(buildId);
+            }
+
+            [Fact]
+            public void Should_Set_Build_Id_With_Ctor()
+            {
+                // Given
+                var buildId = 42;
+                var creds = new AzureDevOpsNtlmCredentials();
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "https://example.com/collection");
+                Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "MyProject");
+                Environment.SetEnvironmentVariable("BUILD_BUILDID", "20");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var settings = new AzureDevOpsBuildSettings(buildId, creds);
 
                 // Then
                 settings.BuildId.ShouldBe(buildId);

--- a/src/Cake.AzureDevOps/AzureDevOpsAliases.Pipelines.cs
+++ b/src/Cake.AzureDevOps/AzureDevOpsAliases.Pipelines.cs
@@ -90,6 +90,41 @@
         }
 
         /// <summary>
+        /// Gets the description of a specific build which is running the access token provided by Azure Pipelines.
+        /// Make sure the build has the 'Allow Scripts to access OAuth token' option enabled.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="buildId">ID of the build.</param>
+        /// <example>
+        /// <para>Get an Azure Pipelines build:</para>
+        /// <code>
+        /// <![CDATA[
+        /// var build =
+        ///     AzureDevOpsBuildUsingAzurePipelinesOAuthToken();
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <returns>Description of the build.
+        /// Returns <c>null</c> if build could not be found and
+        /// <see cref="AzureDevOpsBuildSettings.ThrowExceptionIfBuildCouldNotBeFound"/> is set to <c>false</c>.</returns>
+        /// <exception cref="AzureDevOpsBuildNotFoundException">If build could not be found and
+        /// <see cref="AzureDevOpsBuildSettings.ThrowExceptionIfBuildCouldNotBeFound"/> is set to <c>true</c>.</exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Azure Pipelines")]
+        [CakeNamespaceImport("Cake.AzureDevOps.Pipelines")]
+        public static AzureDevOpsBuild AzureDevOpsBuildUsingAzurePipelinesOAuthToken(
+            this ICakeContext context,
+            int buildId)
+        {
+            context.NotNull(nameof(context));
+            buildId.NotNegativeOrZero(nameof(buildId));
+
+            var settings = AzureDevOpsBuildSettings.UsingAzurePipelinesOAuthToken(buildId);
+
+            return AzureDevOpsBuild(context, settings);
+        }
+
+        /// <summary>
         /// Gets Azure Pipelines builds using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.AzureDevOps/EnvironmentVariableHelper.cs
+++ b/src/Cake.AzureDevOps/EnvironmentVariableHelper.cs
@@ -57,5 +57,32 @@
 
             return projectName;
         }
+
+        /// <summary>
+        /// Gets the value for the environment variable 'BUILD_BUILDID'.
+        /// </summary>
+        /// <returns>The value for the environment variable 'BUILD_BUILDID'.</returns>
+        /// <exception cref="InvalidOperationException">If the environment variable was not found, the value is whitespace or less than 1.</exception>
+        public static int GetBuildId()
+        {
+            var buildId = Environment.GetEnvironmentVariable("BUILD_BUILDID", EnvironmentVariableTarget.Process);
+            if (string.IsNullOrWhiteSpace(buildId))
+            {
+                throw new InvalidOperationException(
+                    "Failed to read the BUILD_BUILDID environment variable. Make sure you are running in an Azure Pipelines build.");
+            }
+
+            if (!int.TryParse(buildId, out int buildIdValue))
+            {
+                throw new InvalidOperationException("BUILD_BUILDID environment variable should contain integer value");
+            }
+
+            if (buildIdValue <= 0)
+            {
+                throw new InvalidOperationException("BUILD_BUILDID environment variable should contain integer value and it should be greater than zero");
+            }
+
+            return buildIdValue;
+        }
     }
 }


### PR DESCRIPTION
Add overload for `AzureDevOpsBuildSettings.UsingAzurePipelinesOAuthToken` providing a build id 

Resolves #239