### PR TITLE
Create all test results in GetTestRuns before disposing the TestManagementHttpClient

### DIFF
--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsBuild.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsBuild.cs
@@ -436,7 +436,7 @@
                                     this.GetTestResults(testClient, runId)
                                     .GetAwaiter()
                                     .GetResult(),
-                            });
+                            }).ToList();
             }
         }
 


### PR DESCRIPTION
Create all test results in GetTestRuns before disposing the TestManagementHttpClient

Resolves #251