### PR TITLE
(GH-273) Change type of AzureDevOpsArtifactResource.Type  to AzurePipelinesArtifactType

### DIFF
--- a/src/Cake.AzureDevOps/Cake.AzureDevOps.csproj
+++ b/src/Cake.AzureDevOps/Cake.AzureDevOps.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cake.Common" Version="1.0.0" />
     <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.AzureDevOps/Pipelines/ArtifactResourceExtensions.cs
+++ b/src/Cake.AzureDevOps/Pipelines/ArtifactResourceExtensions.cs
@@ -1,5 +1,7 @@
 ﻿namespace Cake.AzureDevOps.Pipelines
 {
+    using System;
+    using Cake.Common.Build.AzurePipelines.Data;
     using Microsoft.TeamFoundation.Build.WebApi;
 
     /// <summary>
@@ -16,12 +18,17 @@
         {
             artifactResource.NotNull(nameof(artifactResource));
 
+            if (!Enum.TryParse(artifactResource.Type, out AzurePipelinesArtifactType type))
+            {
+                throw new Exception($"Unexpected value for artifact type '{artifactResource.Type}'");
+            }
+
             return
                 new AzureDevOpsArtifactResource
                 {
                     Data = artifactResource.Data,
                     DownloadUrl = artifactResource.DownloadUrl,
-                    Type = artifactResource.Type,
+                    Type = type,
                     Url = artifactResource.Url,
                     Properties = artifactResource.Properties,
                 };

--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsArtifactResource.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsArtifactResource.cs
@@ -1,6 +1,7 @@
 ﻿namespace Cake.AzureDevOps.Pipelines
 {
     using System.Collections.Generic;
+    using Cake.Common.Build.AzurePipelines.Data;
 
     /// <summary>
     /// Represents a resource associated with a <see cref="AzureDevOpsBuildArtifact" />.
@@ -20,7 +21,7 @@
         /// <summary>
         /// Gets the type of the resource.
         /// </summary>
-        public string Type { get; internal set; }
+        public AzurePipelinesArtifactType Type { get; internal set; }
 
         /// <summary>
         /// Gets the full http link to the resource.


### PR DESCRIPTION
Change type of AzureDevOpsArtifactResource.Type  to AzurePipelinesArtifactType.

Fixes #297 