### PR TITLE
(GH-322) Support deleting comments

### DIFF
--- a/src/Cake.AzureDevOps.Tests/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.AzureDevOps.Tests/Fakes/FakeAllSetGitClientFactory.cs
@@ -161,8 +161,8 @@
                     },
                     Comments = new List<Comment>
                     {
-                        new Comment { Content = "Hello", IsDeleted = false, CommentType = CommentType.CodeChange },
-                        new Comment { Content = "Goodbye", IsDeleted = true, CommentType = CommentType.Text },
+                        new Comment { Content = "Hello", IsDeleted = false, CommentType = CommentType.CodeChange, Id = 1 },
+                        new Comment { Content = "Goodbye", IsDeleted = true, CommentType = CommentType.Text, Id = 2 },
                     },
                     Status = CommentThreadStatus.Active,
                 },

--- a/src/Cake.AzureDevOps.Tests/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.AzureDevOps.Tests/Fakes/FakeAllSetGitClientFactory.cs
@@ -307,6 +307,21 @@
                     return gitPullRequestToCreate;
                  });
 
+            m.Setup(arg => arg.UpdateCommentAsync(
+                   It.IsAny<Comment>(),
+                   It.IsAny<Guid>(),
+                   It.IsAny<int>(),
+                   It.IsAny<int>(),
+                   It.IsAny<int>(),
+                   null,
+                   CancellationToken.None))
+               .ReturnsAsync((Comment comment, Guid repositoryId, int prId, int threadId, int commentId, object o, CancellationToken c)
+                   => new Comment
+                   {
+                        Id = comment.Id,
+                        Content = comment.Content,
+                   });
+
             return m;
         }
     }

--- a/src/Cake.AzureDevOps.Tests/Fakes/FakeNullForMethodsGitClientFactory.cs
+++ b/src/Cake.AzureDevOps.Tests/Fakes/FakeNullForMethodsGitClientFactory.cs
@@ -35,6 +35,9 @@
             m.Setup(arg => arg.GetPullRequestIterationChangesAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), null, null, null, null, CancellationToken.None))
              .ReturnsAsync(() => null);
 
+            m.Setup(arg => arg.UpdateCommentAsync(It.IsAny<Comment>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), null, CancellationToken.None))
+            .ReturnsAsync(() => null);
+
             return m;
         }
     }

--- a/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace Cake.AzureDevOps.Tests.Repos.PullRequest
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Cake.AzureDevOps.Repos.PullRequest;
     using Cake.AzureDevOps.Repos.PullRequest.CommentThread;
     using Cake.AzureDevOps.Tests.Fakes;
@@ -7,9 +10,6 @@
     using Cake.Core.IO;
     using Microsoft.VisualStudio.Services.Common;
     using Shouldly;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Xunit;
 
     public sealed class AzureDevOpsPullRequestTests

--- a/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace Cake.AzureDevOps.Tests.Repos.PullRequest
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Cake.AzureDevOps.Repos.PullRequest;
     using Cake.AzureDevOps.Repos.PullRequest.CommentThread;
     using Cake.AzureDevOps.Tests.Fakes;
@@ -10,6 +7,9 @@
     using Cake.Core.IO;
     using Microsoft.VisualStudio.Services.Common;
     using Shouldly;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Xunit;
 
     public sealed class AzureDevOpsPullRequestTests
@@ -849,17 +849,17 @@
             }
 
             [Theory]
-            [InlineData((FilePath)null, typeof(ArgumentNullException))]
+            [InlineData((string)null, typeof(ArgumentNullException))]
             [InlineData("", typeof(ArgumentOutOfRangeException))]
             [InlineData(" ", typeof(ArgumentOutOfRangeException))]
-            public void Should_Throw_If_FilePath_Is_Null_Or_Empty_Or_Whitespace(FilePath filePath, Type expectedExceptionType)
+            public void Should_Throw_If_FilePath_Is_Null_Or_Empty_Or_Whitespace(string filePath, Type expectedExceptionType)
             {
                 // Given
                 var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100);
                 var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
 
                 // When
-                var result = Record.Exception(() => pullRequest.CreateComment("test", filePath, 0, 0)) as ArgumentException;
+                var result = Record.Exception(() => pullRequest.CreateComment("test", filePath == null ? null : new FilePath(filePath), 0, 0)) as ArgumentException;
 
                 // Then
                 result.ShouldNotBeNull();

--- a/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
@@ -879,6 +879,109 @@
                 // Then
                 // ?? Nothing to validate here since the method returns void
             }
+
+            [Fact]
+            public void Should_Throw_If_Comment_Is_Null()
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100);
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var result = Record.Exception(() => pullRequest.DeleteComment(null)) as ArgumentException;
+
+                // Then
+                result.ShouldNotBeNull();
+                result.IsArgumentNullException("comment");
+            }
+
+            [Fact]
+            public void Should_Delete_Comment_By_Comment_Properties()
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100);
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+                var inComment = new AzureDevOpsComment(new Microsoft.TeamFoundation.SourceControl.WebApi.Comment { Id = 1 }, 5);
+                inComment.Content = "new Content";
+
+                // When
+                pullRequest.DeleteComment(inComment);
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
+            }
+        }
+
+        public sealed class TheUpdateCommentMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Comment_Is_Null()
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100);
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var result = Record.Exception(() => pullRequest.UpdateComment(null)) as ArgumentException;
+
+                // Then
+                result.ShouldNotBeNull();
+                result.IsArgumentNullException("comment");
+            }
+
+            [Fact]
+            public void Should_Return_Null_If_Pull_Request_Is_Invalid()
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100)
+                {
+                    GitClientFactory = new FakeNullGitClientFactory(),
+                };
+                fixture.Settings.ThrowExceptionIfPullRequestCouldNotBeFound = false;
+
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var outThread = pullRequest.UpdateComment(new AzureDevOpsComment());
+
+                // Then
+                outThread.ShouldBeNull();
+            }
+
+            [Fact]
+            public void Should_Return_Null_If_Null_Is_Returned_From_Git_Client()
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100)
+                {
+                    GitClientFactory = new FakeNullForMethodsGitClientFactory(),
+                };
+
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var outThread = pullRequest.UpdateComment(new AzureDevOpsComment());
+
+                // Then
+                outThread.ShouldBeNull();
+            }
+
+            [Fact]
+            public void Should_Return_Updated_Comment()
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsUrl, 200);
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+                var inComment = new AzureDevOpsComment(new Microsoft.TeamFoundation.SourceControl.WebApi.Comment { Id = 1 }, 5);
+                inComment.Content = "new Content";
+
+                // When
+                var outComment = pullRequest.UpdateComment(inComment);
+
+                // Then
+                outComment.Id.ShouldBe(inComment.Id);
+                outComment.Content.ShouldBe(inComment.Content);
+            }
         }
 
         public sealed class TheCreateCommentThreadMethod

--- a/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
@@ -750,12 +750,14 @@
                 comment11.Content.ShouldBe("Hello");
                 comment11.IsDeleted.ShouldBe(false);
                 comment11.CommentType.ShouldBe(AzureDevOpsCommentType.CodeChange);
+                ((int)comment11.Id).ShouldBeGreaterThan(0);
 
                 AzureDevOpsComment comment12 = thread1.Comments.Last();
                 comment12.ShouldNotBeNull();
                 comment12.Content.ShouldBe("Goodbye");
                 comment12.IsDeleted.ShouldBe(true);
                 comment12.CommentType.ShouldBe(AzureDevOpsCommentType.Text);
+                ((int)comment12.Id).ShouldBeGreaterThan(0);
 
                 AzureDevOpsPullRequestCommentThread thread2 = threads.Last();
                 thread2.Id.ShouldBe(22);
@@ -823,6 +825,59 @@
                 comment.CommentType.ShouldBe(AzureDevOpsCommentType.System);
                 comment.IsDeleted.ShouldBeFalse();
                 comment.Content.ShouldBe("Valid");
+            }
+        }
+
+        public sealed class TheDeleteCommentMethod
+        {
+            [Theory]
+            [InlineData(0, typeof(ArgumentOutOfRangeException))]
+            [InlineData(-1, typeof(ArgumentOutOfRangeException))]
+            [InlineData(-55, typeof(ArgumentOutOfRangeException))]
+            public void Should_Throw_If_ThreadId_Is_Zero_Or_Below(int threadId, Type expectedExceptionType)
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100);
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var result = Record.Exception(() => pullRequest.DeleteComment(threadId, 5)) as ArgumentException;
+
+                // Then
+                result.ShouldNotBeNull();
+                result.IsArgumentException(expectedExceptionType, "threadId");
+            }
+
+            [Theory]
+            [InlineData(0, typeof(ArgumentOutOfRangeException))]
+            [InlineData(-1, typeof(ArgumentOutOfRangeException))]
+            [InlineData(-55, typeof(ArgumentOutOfRangeException))]
+            public void Should_Throw_If_CommentId_Is_Zero_Or_Below(int commentId, Type expectedExceptionType)
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100);
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var result = Record.Exception(() => pullRequest.DeleteComment(5, commentId)) as ArgumentException;
+
+                // Then
+                result.ShouldNotBeNull();
+                result.IsArgumentException(expectedExceptionType, "commentId");
+            }
+
+            [Fact]
+            public void Should_Delete_Comment()
+            {
+                // Given
+                var fixture = new PullRequestFixture(BasePullRequestFixture.ValidAzureDevOpsServerUrl, 100);
+                var pullRequest = new AzureDevOpsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                pullRequest.DeleteComment(5, 1);
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
             }
         }
 

--- a/src/Cake.AzureDevOps.Tests/Repos/PullRequest/CommentThread/AzureDevOpsCommentTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Repos/PullRequest/CommentThread/AzureDevOpsCommentTests.cs
@@ -13,10 +13,20 @@
             public void Should_Throw_If_Comment_Is_Null()
             {
                 // Given, When
-                var result = Record.Exception(() => new AzureDevOpsComment(null));
+                var result = Record.Exception(() => new AzureDevOpsComment(null, 1));
 
                 // Then
                 result.IsArgumentNullException("comment");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ThreadId_Is_Negative()
+            {
+                // Given, When
+                var result = Record.Exception(() => new AzureDevOpsComment(new Comment(), -1));
+
+                // Then
+                result.IsArgumentOutOfRangeException("threadId");
             }
 
             [Fact]
@@ -50,6 +60,7 @@
                 comment.Content.ShouldBe(default(string));
                 comment.IsDeleted.ShouldBe(default(bool));
                 comment.CommentType.ShouldBe(default(AzureDevOpsCommentType));
+                comment.ThreadId.ShouldBe(0);
             }
 
             [Fact]
@@ -63,6 +74,7 @@
                 comment.Content.ShouldBe("Hello");
                 comment.IsDeleted.ShouldBeFalse();
                 comment.CommentType.ShouldBe(default(AzureDevOpsCommentType));
+                comment.ThreadId.ShouldBe(0);
             }
 
             [Fact]

--- a/src/Cake.AzureDevOps/ArgumentChecks.cs
+++ b/src/Cake.AzureDevOps/ArgumentChecks.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using Cake.Core.IO;
 
     /// <summary>
     /// Common runtime checks that throw <see cref="ArgumentException"/> upon failure.
@@ -41,6 +42,27 @@
             }
 
             if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentOutOfRangeException(parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an exception if the specified parameter's value is null, empty or consists only of white-space characters.
+        /// </summary>
+        /// <param name="value">The value of the argument.</param>
+        /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> is empty or consists only of white-space characters.</exception>
+        [DebuggerStepThrough]
+        public static void NotNullOrWhiteSpace([ValidatedNotNull] this FilePath value, string parameterName)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(parameterName);
+            }
+
+            if (string.IsNullOrWhiteSpace(value.FullPath))
             {
                 throw new ArgumentOutOfRangeException(parameterName);
             }

--- a/src/Cake.AzureDevOps/ArgumentChecks.cs
+++ b/src/Cake.AzureDevOps/ArgumentChecks.cs
@@ -60,5 +60,20 @@
                 throw new ArgumentOutOfRangeException(parameterName);
             }
         }
+
+        /// <summary>
+        /// Throws an exception if the specified parameter's value is negative.
+        /// </summary>
+        /// <param name="value">The value of the argument.</param>
+        /// <param name="parameterName">The name of the parameter to include in any thrown exception.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> is negative or zero.</exception>
+        [DebuggerStepThrough]
+        public static void NotNegative(this int value, string parameterName)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(parameterName);
+            }
+        }
     }
 }

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
@@ -624,6 +624,54 @@
         }
 
         /// <summary>
+        /// Deletes the comment.
+        /// </summary>
+        /// <param name="comment">The comment to delete.</param>am>
+        public void DeleteComment(AzureDevOpsComment comment)
+        {
+            comment.NotNull(nameof(comment));
+
+            this.DeleteComment(comment.ThreadId, comment.Id);
+        }
+
+        /// <summary>
+        /// Updates the comment.
+        /// </summary>
+        /// <param name="comment">The updated comment.</param>
+        /// <returns>The updated comment, or null if it can't be updated.</returns>
+        public AzureDevOpsComment UpdateComment(AzureDevOpsComment comment)
+        {
+            comment.NotNull(nameof(comment));
+
+            AzureDevOpsComment resultingComment = null;
+            if (!this.ValidatePullRequest())
+            {
+                return resultingComment;
+            }
+
+            using (var gitClient = this.gitClientFactory.CreateGitClient(this.CollectionUrl, this.credentials))
+            {
+                var newComment = gitClient
+                    .UpdateCommentAsync(
+                        comment.Comment,
+                        this.RepositoryId,
+                        this.PullRequestId,
+                        comment.ThreadId,
+                        comment.Id)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+
+                if (newComment != null)
+                {
+                    resultingComment = new AzureDevOpsComment(newComment, comment.ThreadId);
+                }
+            }
+
+            return resultingComment;
+        }
+
+        /// <summary>
         /// Creates a new comment thread in the pull request.
         /// </summary>
         /// <param name="thread">The instance of the thread.</param>

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
@@ -600,6 +600,41 @@
         }
 
         /// <summary>
+        /// Creates a new comment thread for the given file and position.
+        /// </summary>
+        /// <param name="comment">Comment which should be added.</param>
+        /// <param name="filePath">Path to the file to create the comment for.</param>
+        /// <param name="lineNumber">The line number of a thread's position. Starts at 1.</param>
+        /// <param name="offset">The character offset of a thread's position inside of a line. Starts at 0.</param>
+        /// <returns>A newly created comment thread, or null if it can't be created.</returns>
+        public AzureDevOpsPullRequestCommentThread CreateComment(string comment, FilePath filePath, int lineNumber, int offset)
+        {
+            comment.NotNullOrWhiteSpace(nameof(comment));
+            filePath.NotNullOrWhiteSpace(nameof(filePath));
+            lineNumber.NotNegativeOrZero(nameof(lineNumber));
+            offset.NotNegative(nameof(offset));
+
+            var thread = new AzureDevOpsPullRequestCommentThread
+            {
+                Status = AzureDevOpsCommentThreadStatus.Active,
+                Comments = new List<AzureDevOpsComment>
+                {
+                    new AzureDevOpsComment
+                    {
+                        CommentType = AzureDevOpsCommentType.System,
+                        IsDeleted = false,
+                        Content = comment,
+                    },
+                },
+                FilePath = filePath,
+                LineNumber = lineNumber,
+                Offset = offset,
+            };
+
+            return this.CreateCommentThread(thread);
+        }
+
+        /// <summary>
         /// Deletes the comment in the given thread.
         /// </summary>
         /// <param name="threadId">The id of the thread containing the comment.</param>

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
@@ -600,6 +600,30 @@
         }
 
         /// <summary>
+        /// Deletes the comment in the given thread.
+        /// </summary>
+        /// <param name="threadId">The id of the thread containing the comment.</param>
+        /// <param name="commentId">The id of the comment to delete.</param>
+        public void DeleteComment(int threadId, int commentId)
+        {
+            threadId.NotNegativeOrZero(nameof(threadId));
+            commentId.NotNegativeOrZero(nameof(commentId));
+
+            using (var gitClient = this.gitClientFactory.CreateGitClient(this.CollectionUrl, this.credentials))
+            {
+                gitClient
+                    .DeleteCommentAsync(
+                        this.RepositoryId,
+                        this.PullRequestId,
+                        threadId,
+                        commentId)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+            }
+        }
+
+        /// <summary>
         /// Creates a new comment thread in the pull request.
         /// </summary>
         /// <param name="thread">The instance of the thread.</param>

--- a/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsComment.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsComment.cs
@@ -41,6 +41,14 @@
         }
 
         /// <summary>
+        /// Gets the comment id.
+        /// </summary>
+        public short Id
+        {
+            get => this.comment.Id;
+        }
+
+        /// <summary>
         /// Gets or sets the content of the pull request comment.
         /// </summary>
         public string Content

--- a/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsComment.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsComment.cs
@@ -8,6 +8,7 @@
     public class AzureDevOpsComment
     {
         private readonly Comment comment;
+        private readonly int threadId;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureDevOpsComment"/> class.
@@ -19,13 +20,14 @@
             content.NotNullOrWhiteSpace(nameof(content));
 
             this.comment = new Comment { Content = content, IsDeleted = isDeleted };
+            this.threadId = 0;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureDevOpsComment"/> class with empty Git comment.
         /// </summary>
         public AzureDevOpsComment()
-            : this(new Comment())
+            : this(new Comment(), 0)
         {
         }
 
@@ -33,11 +35,14 @@
         /// Initializes a new instance of the <see cref="AzureDevOpsComment"/> class with real Git comment.
         /// </summary>
         /// <param name="comment">The original Azure DevOps pull request comment.</param>
-        internal AzureDevOpsComment(Comment comment)
+        /// <param name="threadId">The parent thread ID.</param>
+        internal AzureDevOpsComment(Comment comment, int threadId)
         {
             comment.NotNull(nameof(comment));
+            threadId.NotNegative(nameof(threadId));
 
             this.comment = comment;
+            this.threadId = threadId;
         }
 
         /// <summary>
@@ -46,6 +51,14 @@
         public short Id
         {
             get => this.comment.Id;
+        }
+
+        /// <summary>
+        /// Gets the thread id.
+        /// </summary>
+        public int ThreadId
+        {
+            get => this.threadId;
         }
 
         /// <summary>
@@ -73,6 +86,14 @@
         {
             get => (AzureDevOpsCommentType)this.comment.CommentType;
             set => this.comment.CommentType = (CommentType)value;
+        }
+
+        /// <summary>
+        /// Gets the internal comment.
+        /// </summary>
+        internal Comment Comment
+        {
+            get => this.comment;
         }
     }
 }

--- a/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
@@ -91,7 +91,7 @@
                     throw new InvalidOperationException("Comments list is not created.");
                 }
 
-                return this.thread.Comments.Select(x => new AzureDevOpsComment(x));
+                return this.thread.Comments.Select(x => new AzureDevOpsComment(x, this.thread.Id));
             }
 
             set

--- a/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
@@ -1,11 +1,11 @@
 ﻿namespace Cake.AzureDevOps.Repos.PullRequest.CommentThread
 {
-    using Cake.Core.IO;
-    using Microsoft.TeamFoundation.SourceControl.WebApi;
-    using Microsoft.VisualStudio.Services.WebApi;
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Cake.Core.IO;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Microsoft.VisualStudio.Services.WebApi;
 
     /// <summary>
     /// Class for dealing with comments in pull requests.

--- a/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
@@ -80,6 +80,76 @@
         }
 
         /// <summary>
+        /// Gets or sets the line number of the right file.
+        /// Returns 'null' for the comment threads not related to any particular file and position.
+        /// </summary>
+        public int? LineNumber
+        {
+            get
+            {
+                if (this.thread.ThreadContext?.RightFileStart != null)
+                {
+                    return this.thread.ThreadContext?.RightFileStart.Line;
+                }
+
+                return null;
+            }
+
+            set
+            {
+                if (value != null)
+                {
+                    if (this.thread.ThreadContext == null)
+                    {
+                        this.thread.ThreadContext = new CommentThreadContext();
+                    }
+
+                    if (this.thread.ThreadContext.RightFileStart == null)
+                    {
+                        this.thread.ThreadContext.RightFileStart = new CommentPosition();
+                    }
+
+                    this.thread.ThreadContext.RightFileStart.Line = value.Value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the character offset inside of a line.
+        /// Returns 'null' for the comment threads not related to any particular file and position.
+        /// </summary>
+        public int? Offset
+        {
+            get
+            {
+                if (this.thread.ThreadContext?.RightFileStart != null)
+                {
+                    return this.thread.ThreadContext?.RightFileStart.Offset;
+                }
+
+                return null;
+            }
+
+            set
+            {
+                if (value != null)
+                {
+                    if (this.thread.ThreadContext == null)
+                    {
+                        this.thread.ThreadContext = new CommentThreadContext();
+                    }
+
+                    if (this.thread.ThreadContext.RightFileStart == null)
+                    {
+                        this.thread.ThreadContext.RightFileStart = new CommentPosition();
+                    }
+
+                    this.thread.ThreadContext.RightFileStart.Offset = value.Value;
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the collection of comments in the pull request comment thread.
         /// </summary>
         public IEnumerable<AzureDevOpsComment> Comments

--- a/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
@@ -1,11 +1,11 @@
 ﻿namespace Cake.AzureDevOps.Repos.PullRequest.CommentThread
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Cake.Core.IO;
     using Microsoft.TeamFoundation.SourceControl.WebApi;
     using Microsoft.VisualStudio.Services.WebApi;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Class for dealing with comments in pull requests.
@@ -99,15 +99,7 @@
             {
                 if (value != null)
                 {
-                    if (this.thread.ThreadContext == null)
-                    {
-                        this.thread.ThreadContext = new CommentThreadContext();
-                    }
-
-                    if (this.thread.ThreadContext.RightFileStart == null)
-                    {
-                        this.thread.ThreadContext.RightFileStart = new CommentPosition();
-                    }
+                    this.EnsureRightFileStartExists();
 
                     this.thread.ThreadContext.RightFileStart.Line = value.Value;
                 }
@@ -134,15 +126,7 @@
             {
                 if (value != null)
                 {
-                    if (this.thread.ThreadContext == null)
-                    {
-                        this.thread.ThreadContext = new CommentThreadContext();
-                    }
-
-                    if (this.thread.ThreadContext.RightFileStart == null)
-                    {
-                        this.thread.ThreadContext.RightFileStart = new CommentPosition();
-                    }
+                    this.EnsureRightFileStartExists();
 
                     this.thread.ThreadContext.RightFileStart.Offset = value.Value;
                 }
@@ -225,6 +209,19 @@
             else
             {
                 this.thread.Properties.Add(propertyName, value);
+            }
+        }
+
+        private void EnsureRightFileStartExists()
+        {
+            if (this.thread.ThreadContext == null)
+            {
+                this.thread.ThreadContext = new CommentThreadContext();
+            }
+
+            if (this.thread.ThreadContext.RightFileStart == null)
+            {
+                this.thread.ThreadContext.RightFileStart = new CommentPosition();
             }
         }
     }


### PR DESCRIPTION
Provides new methods on `AzureDevOpsPullRequest` to delete, update and create comments
Fixes #322