### PR TITLE
Ignore warning from InspectCode on AppVeyor

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = 'Stop'
-
 $SCRIPT_NAME = "recipe.cake"
 
 Write-Host "Restoring .NET Core tools"


### PR DESCRIPTION
Stop failing build on warnings since InspectCode currently has a warning:

```
Starting from version 2021.2, InspectCode builds the target solution before starting the analysis to make sure it only finds relevant code issues.
```