### PR TITLE
Use Visual Studio 2019 image on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,8 @@
 #---------------------------------#
 #  Build Image                    #
 #---------------------------------#
-image: Visual Studio 2022
+# Cake recipe requires .NET Core 2.1 which is not available on newer images
+image: Visual Studio 2019
 
 #---------------------------------#
 #  Build Script                   #


### PR DESCRIPTION
Use Visual Studio 2019 image on AppVeyor as .NET Core 2.1, which is required by some tools used by Cake.Recipe, won't be available on newer images.