### PR TITLE
(GH-353) Add missing dependency

### DIFF
--- a/src/Cake.AzureDevOps/Cake.AzureDevOps.csproj
+++ b/src/Cake.AzureDevOps/Cake.AzureDevOps.csproj
@@ -74,6 +74,9 @@
       <TfmSpecificPackageFile Include="$(OutputPath)\**\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll">
         <PackagePath>lib\$(TargetFramework)\</PackagePath>
       </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include="$(OutputPath)\**\Microsoft.TeamFoundation.Policy.WebApi.dll">
+        <PackagePath>lib\$(TargetFramework)\</PackagePath>
+      </TfmSpecificPackageFile>
       <TfmSpecificPackageFile Include="$(OutputPath)\**\Microsoft.TeamFoundation.SourceControl.WebApi.dll">
         <PackagePath>lib\$(TargetFramework)\</PackagePath>
       </TfmSpecificPackageFile>


### PR DESCRIPTION
Add missing dependency for Azure DevOps REST API access

Fixes #353 