### PR TITLE
Make properties init-only

### DIFF
--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsArtifactResource.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsArtifactResource.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Pipelines
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Pipelines
 {
     using System.Collections.Generic;
     using Cake.Common.Build.AzurePipelines.Data;

--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsBuildArtifact.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsBuildArtifact.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Pipelines
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Pipelines
 {
     /// <summary>
     /// Represents an artifact associated with a build.

--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsBuildDefinition.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsBuildDefinition.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Pipelines
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Pipelines
 {
     /// <summary>
     /// Representation of a build definition.

--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsBuildsSettings.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsBuildsSettings.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Pipelines
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Pipelines
 {
     using System;
     using Cake.AzureDevOps.Authentication;
@@ -53,41 +54,41 @@
         }
 
         /// <summary>
-        /// Gets or sets the name of the build definition.
+        /// Gets the name of the build definition.
         /// Can be <c>null</c> or <see cref="string.Empty"/>.
         /// </summary>
-        public string BuildDefinitionName { get; set; }
+        public string BuildDefinitionName { get; init; }
 
         /// <summary>
-        /// Gets or sets the name of the branch.
+        /// Gets the name of the branch.
         /// Can be <c>null</c> or <see cref="string.Empty"/>.
         /// </summary>
-        public string BranchName { get; set; }
+        public string BranchName { get; init; }
 
         /// <summary>
-        /// Gets or sets the build status.
+        /// Gets the build status.
         /// </summary>
-        public AzureDevOpsBuildStatus? BuildStatus { get; set; }
+        public AzureDevOpsBuildStatus? BuildStatus { get; init; }
 
         /// <summary>
-        /// Gets or sets the build result.
+        /// Gets the build result.
         /// </summary>
-        public AzureDevOpsBuildResult? BuildResult { get; set; }
+        public AzureDevOpsBuildResult? BuildResult { get; init; }
 
         /// <summary>
-        /// Gets or sets the build query order.
+        /// Gets the build query order.
         /// </summary>
-        public AzureDevOpsBuildQueryOrder? BuildQueryOrder { get; set; }
+        public AzureDevOpsBuildQueryOrder? BuildQueryOrder { get; init; }
 
         /// <summary>
-        /// Gets or sets the maximum number of builds per definition.
+        /// Gets the maximum number of builds per definition.
         /// </summary>
-        public int? MaxBuildsPerDefinition { get; set; }
+        public int? MaxBuildsPerDefinition { get; init; }
 
         /// <summary>
-        /// Gets or sets the maximum number of builds.
+        /// Gets the maximum number of builds.
         /// </summary>
-        public int? Top { get; set; }
+        public int? Top { get; init; }
 
         /// <summary>
         /// Constructs the settings object using the access token provided by Azure Pipelines.

--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsChange.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsChange.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Pipelines
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Pipelines
 {
     using System;
 

--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsTestResult.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsTestResult.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Pipelines
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Pipelines
 {
     /// <summary>
     /// Represents a test result associated with a <see cref="AzureDevOpsTestRun" />.

--- a/src/Cake.AzureDevOps/Pipelines/AzureDevOpsTimelineRecord.cs
+++ b/src/Cake.AzureDevOps/Pipelines/AzureDevOpsTimelineRecord.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Pipelines
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Pipelines
 {
     using System;
 

--- a/src/Cake.AzureDevOps/Repos/AzureDevOpsCommit.cs
+++ b/src/Cake.AzureDevOps/Repos/AzureDevOpsCommit.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Repos
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Repos
 {
     using System.Collections.Generic;
 

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequestIterationChange.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequestIterationChange.cs
@@ -8,18 +8,18 @@
     public class AzureDevOpsPullRequestIterationChange
     {
         /// <summary>
-        /// Gets or sets the file path the iteration change is associated with.
+        /// Gets the file path the iteration change is associated with.
         /// </summary>
-        public FilePath ItemPath { get; set; }
+        public FilePath ItemPath { get; init; }
 
         /// <summary>
-        /// Gets or sets the id of the iteration change.
+        /// Gets the id of the iteration change.
         /// </summary>
-        public int ChangeId { get; set; }
+        public int ChangeId { get; init; }
 
         /// <summary>
-        /// Gets or sets the tracking id of the iteration change.
+        /// Gets the tracking id of the iteration change.
         /// </summary>
-        public int ChangeTrackingId { get; set; }
+        public int ChangeTrackingId { get; init; }
     }
 }

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequestSettings.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequestSettings.cs
@@ -84,7 +84,7 @@
         /// <summary>
         /// Gets the ID of the pull request.
         /// </summary>
-        public int? PullRequestId { get; private set; }
+        public int? PullRequestId { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether an exception should be thrown if

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequestStatus.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequestStatus.cs
@@ -1,4 +1,5 @@
-﻿namespace Cake.AzureDevOps.Repos.PullRequest
+﻿// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Cake.AzureDevOps.Repos.PullRequest
 {
     using System;
 
@@ -24,23 +25,23 @@
         public string Name { get; }
 
         /// <summary>
-        /// Gets or sets the genre of the status.
+        /// Gets the genre of the status.
         /// </summary>
-        public string Genre { get; set; }
+        public string Genre { get; init; }
 
         /// <summary>
-        /// Gets or sets the state of the pull request.
+        /// Gets the state of the pull request.
         /// </summary>
-        public AzureDevOpsPullRequestStatusState State { get; set; }
+        public AzureDevOpsPullRequestStatusState State { get; init; }
 
         /// <summary>
-        /// Gets or sets the description of the status.
+        /// Gets the description of the status.
         /// </summary>
-        public string Description { get; set; }
+        public string Description { get; init; }
 
         /// <summary>
-        /// Gets or sets the URL of the status.
+        /// Gets the URL of the status.
         /// </summary>
-        public Uri TargetUrl { get; set; }
+        public Uri TargetUrl { get; init; }
     }
 }

--- a/src/Cake.AzureDevOps/Repos/PullRequest/BaseAzureDevOpsPullRequestSettings.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/BaseAzureDevOpsPullRequestSettings.cs
@@ -79,7 +79,7 @@
         /// <summary>
         /// Gets the full URL of the Git repository, eg. <code>http://myserver:8080/defaultcollection/myproject/_git/myrepository</code>.
         /// </summary>
-        public Uri RepositoryUrl { get; private set; }
+        public Uri RepositoryUrl { get; }
 
         /// <summary>
         /// Gets the branch for which the pull request is made.
@@ -90,6 +90,6 @@
         /// <summary>
         /// Gets the branch for which the pull request is made.
         /// </summary>
-        public string SourceRefName { get; private set; }
+        public string SourceRefName { get; }
     }
 }

--- a/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsComment.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsComment.cs
@@ -53,30 +53,30 @@
         public int ThreadId { get; }
 
         /// <summary>
-        /// Gets or sets the content of the pull request comment.
+        /// Gets the content of the pull request comment.
         /// </summary>
         public string Content
         {
             get => this.Comment.Content;
-            set => this.Comment.Content = value;
+            init => this.Comment.Content = value;
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the comment is deleted.
+        /// Gets a value indicating whether the comment is deleted.
         /// </summary>
         public bool IsDeleted
         {
             get => this.Comment.IsDeleted;
-            set => this.Comment.IsDeleted = value;
+            init => this.Comment.IsDeleted = value;
         }
 
         /// <summary>
-        /// Gets or sets the comment type.
+        /// Gets the comment type.
         /// </summary>
         public AzureDevOpsCommentType CommentType
         {
             get => (AzureDevOpsCommentType)this.Comment.CommentType;
-            set => this.Comment.CommentType = (CommentType)value;
+            init => this.Comment.CommentType = (CommentType)value;
         }
 
         /// <summary>

--- a/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/CommentThread/AzureDevOpsPullRequestCommentThread.cs
@@ -12,8 +12,6 @@
     /// </summary>
     public class AzureDevOpsPullRequestCommentThread
     {
-        private readonly GitPullRequestCommentThread thread;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureDevOpsPullRequestCommentThread"/> class.
         /// </summary>
@@ -25,128 +23,128 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureDevOpsPullRequestCommentThread"/> class.
         /// </summary>
-        /// <param name="thread">The original comment thread in the Azue DevOps pull request.</param>
+        /// <param name="thread">The original comment thread in the Azure DevOps pull request.</param>
         internal AzureDevOpsPullRequestCommentThread(GitPullRequestCommentThread thread)
         {
             thread.NotNull(nameof(thread));
 
-            this.thread = thread;
+            this.InnerThread = thread;
         }
 
         /// <summary>
-        /// Gets or sets the Id of the pull request comment thread.
+        /// Gets the Id of the pull request comment thread.
         /// </summary>
         public int Id
         {
-            get => this.thread.Id;
-            set => this.thread.Id = value;
+            get => this.InnerThread.Id;
+            init => this.InnerThread.Id = value;
         }
 
         /// <summary>
-        /// Gets or sets the status of the pull request comment thread.
+        /// Gets the status of the pull request comment thread.
         /// </summary>
         public AzureDevOpsCommentThreadStatus Status
         {
-            get => (AzureDevOpsCommentThreadStatus)this.thread.Status;
-            set => this.thread.Status = (CommentThreadStatus)value;
+            get => (AzureDevOpsCommentThreadStatus)this.InnerThread.Status;
+            init => this.InnerThread.Status = (CommentThreadStatus)value;
         }
 
         /// <summary>
-        /// Gets or sets the path of the modified file the pull request comment thread belongs to.
-        /// Returns 'null' for the comment threads not related to any particular file.
+        /// Gets the path of the modified file the pull request comment thread belongs to.
+        /// Returns <c>null</c> for the comment threads not related to any particular file.
         /// </summary>
         public FilePath FilePath
         {
             get
             {
                 FilePath filePath = null;
-                if (this.thread.ThreadContext?.FilePath != null)
+                if (this.InnerThread.ThreadContext?.FilePath != null)
                 {
-                    filePath = this.thread.ThreadContext.FilePath.TrimStart('/');
+                    filePath = this.InnerThread.ThreadContext.FilePath.TrimStart('/');
                 }
 
                 return filePath;
             }
 
-            set
+            init
             {
-                this.thread.ThreadContext ??= new CommentThreadContext();
+                this.InnerThread.ThreadContext ??= new CommentThreadContext();
 
-                this.thread.ThreadContext.FilePath = value.FullPath;
+                this.InnerThread.ThreadContext.FilePath = value.FullPath;
             }
         }
 
         /// <summary>
-        /// Gets or sets the line number of the right file.
-        /// Returns 'null' for the comment threads not related to any particular file and position.
+        /// Gets the line number of the right file.
+        /// Returns <c>null</c> for the comment threads not related to any particular file and position.
         /// </summary>
         public int? LineNumber
         {
             get
             {
-                if (this.thread.ThreadContext?.RightFileStart != null)
+                if (this.InnerThread.ThreadContext?.RightFileStart != null)
                 {
-                    return this.thread.ThreadContext?.RightFileStart.Line;
+                    return this.InnerThread.ThreadContext?.RightFileStart.Line;
                 }
 
                 return null;
             }
 
-            set
+            init
             {
                 if (value != null)
                 {
                     this.EnsureRightFileStartExists();
 
-                    this.thread.ThreadContext.RightFileStart.Line = value.Value;
+                    this.InnerThread.ThreadContext.RightFileStart.Line = value.Value;
                 }
             }
         }
 
         /// <summary>
-        /// Gets or sets the character offset inside of a line.
-        /// Returns 'null' for the comment threads not related to any particular file and position.
+        /// Gets the character offset inside of a line.
+        /// Returns <c>null</c> for the comment threads not related to any particular file and position.
         /// </summary>
         public int? Offset
         {
             get
             {
-                if (this.thread.ThreadContext?.RightFileStart != null)
+                if (this.InnerThread.ThreadContext?.RightFileStart != null)
                 {
-                    return this.thread.ThreadContext?.RightFileStart.Offset;
+                    return this.InnerThread.ThreadContext?.RightFileStart.Offset;
                 }
 
                 return null;
             }
 
-            set
+            init
             {
                 if (value != null)
                 {
                     this.EnsureRightFileStartExists();
 
-                    this.thread.ThreadContext.RightFileStart.Offset = value.Value;
+                    this.InnerThread.ThreadContext.RightFileStart.Offset = value.Value;
                 }
             }
         }
 
         /// <summary>
-        /// Gets or sets the collection of comments in the pull request comment thread.
+        /// Gets the collection of comments in the pull request comment thread.
         /// </summary>
         public IEnumerable<AzureDevOpsComment> Comments
         {
             get
             {
-                if (this.thread.Comments == null)
+                if (this.InnerThread.Comments == null)
                 {
                     throw new InvalidOperationException("Comments list is not created.");
                 }
 
-                return this.thread.Comments.Select(x => new AzureDevOpsComment(x, this.thread.Id));
+                return this.InnerThread.Comments.Select(x => new AzureDevOpsComment(x, this.InnerThread.Id));
             }
 
-            set =>
-                this.thread.Comments =
+            init =>
+                this.InnerThread.Comments =
                     value?
                         .Select(c =>
                             new Comment
@@ -158,18 +156,18 @@
         }
 
         /// <summary>
-        /// Gets or sets the collection of properties of the pull request comment thread.
+        /// Gets the collection of properties of the pull request comment thread.
         /// </summary>
         public IDictionary<string, object> Properties
         {
-            get => this.thread.Properties;
-            set => this.thread.Properties = value != null ? new PropertiesCollection(value) : null;
+            get => this.InnerThread.Properties;
+            init => this.InnerThread.Properties = value != null ? new PropertiesCollection(value) : null;
         }
 
         /// <summary>
         /// Gets the inner Git comment thread object. Intended for the internal use only.
         /// </summary>
-        internal GitPullRequestCommentThread InnerThread => this.thread;
+        internal GitPullRequestCommentThread InnerThread { get; }
 
         /// <summary>
         /// Gets the value of the thread property.
@@ -181,12 +179,12 @@
         {
             propertyName.NotNullOrWhiteSpace(nameof(propertyName));
 
-            if (this.thread.Properties == null)
+            if (this.InnerThread.Properties == null)
             {
                 return default;
             }
 
-            return this.thread.Properties.GetValue(propertyName, default(T));
+            return this.InnerThread.Properties.GetValue(propertyName, default(T));
         }
 
         /// <summary>
@@ -200,25 +198,25 @@
         {
             propertyName.NotNullOrWhiteSpace(nameof(propertyName));
 
-            if (this.thread.Properties == null)
+            if (this.InnerThread.Properties == null)
             {
                 throw new InvalidOperationException("Properties collection is not created.");
             }
 
-            if (this.thread.Properties.ContainsKey(propertyName))
+            if (this.InnerThread.Properties.ContainsKey(propertyName))
             {
-                this.thread.Properties[propertyName] = value;
+                this.InnerThread.Properties[propertyName] = value;
             }
             else
             {
-                this.thread.Properties.Add(propertyName, value);
+                this.InnerThread.Properties.Add(propertyName, value);
             }
         }
 
         private void EnsureRightFileStartExists()
         {
-            this.thread.ThreadContext ??= new CommentThreadContext();
-            this.thread.ThreadContext.RightFileStart ??= new CommentPosition();
+            this.InnerThread.ThreadContext ??= new CommentThreadContext();
+            this.InnerThread.ThreadContext.RightFileStart ??= new CommentPosition();
         }
     }
 }


### PR DESCRIPTION
Make properties of `AzureDevOpsBuildsSettings`, `AzureDevOpsPullRequestIterationChange`, `AzureDevOpsPullRequestStatus`, `AzureDevOpsComments` and `AzureDevOpsPullRequestCommentThread` only settable during object construction.