### PR TITLE
Revert "Update dependency Moq to v4.20.0 (#418)"

### DIFF
--- a/src/Cake.AzureDevOps.Tests/Cake.AzureDevOps.Tests.csproj
+++ b/src/Cake.AzureDevOps.Tests/Cake.AzureDevOps.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Cake.Core" Version="3.0.0" />
     <PackageReference Include="Cake.Testing" Version="3.0.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
-    <PackageReference Include="Moq" Version="4.20.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="xunit" Version="2.5.0" />


### PR DESCRIPTION
Revert update to Moq to > 4.20 due to inclusion of sponsorware that runs during the build.

See https://github.com/moq/moq/issues/1372 for details

This reverts commit 5eba297109f5ff76deecf10cd1491a6b559c17af.