### PR TITLE
Make artifact type comparison case-insensitive

### DIFF
--- a/src/Cake.AzureDevOps.Tests/Cake.AzureDevOps.Tests.csproj
+++ b/src/Cake.AzureDevOps.Tests/Cake.AzureDevOps.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Cake.Common" Version="3.0.0" />
     <PackageReference Include="Cake.Core" Version="3.0.0" />
     <PackageReference Include="Cake.Testing" Version="3.0.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />

--- a/src/Cake.AzureDevOps.Tests/Pipelines/ArtifactResourceExtensionsTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Pipelines/ArtifactResourceExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿namespace Cake.AzureDevOps.Tests.Pipelines
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Cake.AzureDevOps.Pipelines;
+    using Cake.Common.Build.AzurePipelines.Data;
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using Shouldly;
+    using Xunit;
+
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public sealed class ArtifactResourceExtensionsTests
+    {
+        public sealed class TheToAzureDevOpsArtifactResourceExtensionMethod
+        {
+            [Fact]
+            public void Should_Return_The_Correct_AzureDevOpsArtifactResource_For_ArtifactResource()
+            {
+                // Given
+                var artifactResource = new ArtifactResource()
+                {
+                    Data = "data",
+                    DownloadUrl = "downloadUrl",
+                    Url = "url",
+                    Type = "FilePath",
+                    Properties = new Dictionary<string, string>()
+                    {
+                        { "foo", "bar" },
+                    },
+                };
+
+                // When
+                var result = artifactResource.ToAzureDevOpsArtifactResource();
+
+                // Then
+                result.Data.ShouldBe(artifactResource.Data);
+                result.DownloadUrl.ShouldBe(artifactResource.DownloadUrl);
+                result.Url.ShouldBe(artifactResource.Url);
+                result.Type.ShouldBe(AzurePipelinesArtifactType.FilePath);
+                result.Properties.Count.ShouldBe(1);
+                result.Properties.First().Key.ShouldBe(artifactResource.Properties.First().Key);
+                result.Properties.First().Value.ShouldBe(artifactResource.Properties.First().Value);
+            }
+
+            [Theory]
+            [InlineData("container", AzurePipelinesArtifactType.Container)]
+            [InlineData("Container", AzurePipelinesArtifactType.Container)]
+            [InlineData("FilePath", AzurePipelinesArtifactType.FilePath)]
+            [InlineData("filepath", AzurePipelinesArtifactType.FilePath)]
+            [InlineData("GitRef", AzurePipelinesArtifactType.GitRef)]
+            [InlineData("gitref", AzurePipelinesArtifactType.GitRef)]
+            [InlineData("TFVCLabel", AzurePipelinesArtifactType.TFVCLabel)]
+            [InlineData("tfvclabel", AzurePipelinesArtifactType.TFVCLabel)]
+            [InlineData("VersionControl", AzurePipelinesArtifactType.VersionControl)]
+            [InlineData("versioncontrol", AzurePipelinesArtifactType.VersionControl)]
+
+            public void Should_Return_The_Correct_AzureDevOpsArtifactResource_Type_EnumValue_Independent_The_ArtifactResource_Type_String_Casing(string typeString, AzurePipelinesArtifactType artifactType)
+            {
+                // Given
+                var artifactResource = new ArtifactResource()
+                {
+                    Type = typeString,
+                };
+
+                // When
+                var result = artifactResource.ToAzureDevOpsArtifactResource();
+
+                // Then
+                result.Type.ShouldBe(artifactType);
+            }
+        }
+    }
+}

--- a/src/Cake.AzureDevOps.Tests/Pipelines/ArtifactResourceExtensionsTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Pipelines/ArtifactResourceExtensionsTests.cs
@@ -38,8 +38,8 @@
                 result.Url.ShouldBe(artifactResource.Url);
                 result.Type.ShouldBe(AzurePipelinesArtifactType.FilePath);
                 result.Properties.Count.ShouldBe(1);
-                result.Properties.First().Key.ShouldBe(artifactResource.Properties.First().Key);
-                result.Properties.First().Value.ShouldBe(artifactResource.Properties.First().Value);
+                result.Properties.Single().Key.ShouldBe(artifactResource.Properties.Single().Key);
+                result.Properties.Single().Value.ShouldBe(artifactResource.Properties.Single().Value);
             }
 
             [Theory]
@@ -54,7 +54,7 @@
             [InlineData("VersionControl", AzurePipelinesArtifactType.VersionControl)]
             [InlineData("versioncontrol", AzurePipelinesArtifactType.VersionControl)]
 
-            public void Should_Return_The_Correct_AzureDevOpsArtifactResource_Type_EnumValue_Independent_The_ArtifactResource_Type_String_Casing(string typeString, AzurePipelinesArtifactType artifactType)
+            public void Should_Return_The_Correct_AzureDevOpsArtifactResource_Type_EnumValue_Independent_The_ArtifactResource_Type_String_Casing(string typeString, AzurePipelinesArtifactType expectedResult)
             {
                 // Given
                 var artifactResource = new ArtifactResource()
@@ -66,7 +66,7 @@
                 var result = artifactResource.ToAzureDevOpsArtifactResource();
 
                 // Then
-                result.Type.ShouldBe(artifactType);
+                result.Type.ShouldBe(expectedResult);
             }
         }
     }

--- a/src/Cake.AzureDevOps/Pipelines/ArtifactResourceExtensions.cs
+++ b/src/Cake.AzureDevOps/Pipelines/ArtifactResourceExtensions.cs
@@ -18,7 +18,7 @@
         {
             artifactResource.NotNull(nameof(artifactResource));
 
-            if (!Enum.TryParse(artifactResource.Type, out AzurePipelinesArtifactType type))
+            if (!Enum.TryParse(artifactResource.Type, true, out AzurePipelinesArtifactType type))
             {
                 throw new InvalidOperationException($"Unexpected value for artifact type '{artifactResource.Type}'");
             }


### PR DESCRIPTION
Makes the comparison for determine artifact types case-insensitive.

Fixes #430 