### PR TITLE
(GH-435) Don't throw exception if not running in PR build

### DIFF
--- a/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestSettingsTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestSettingsTests.cs
@@ -554,6 +554,36 @@
             }
 
             [Fact]
+            public void Should_Throw_If_Repository_Url_Env_Var_Is_Not_Set_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", null);
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Repository_Url_Env_Var_Is_Not_Set_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", null);
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
+            }
+
+            [Fact]
             public void Should_Throw_If_Repository_Url_Env_Var_Is_Empty()
             {
                 // Given
@@ -566,6 +596,36 @@
 
                 // Then
                 result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Repository_Url_Env_Var_Is_Empty_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", string.Empty);
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Repository_Url_Env_Var_Is_Empty_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", string.Empty);
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
             }
 
             [Fact]
@@ -584,6 +644,36 @@
             }
 
             [Fact]
+            public void Should_Throw_If_Repository_Url_Env_Var_Is_WhiteSpace_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", " ");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Repository_Url_Env_Var_Is_WhiteSpace_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", " ");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
+            }
+
+            [Fact]
             public void Should_Throw_If_Pull_Request_Id_Env_Var_Is_Not_Set()
             {
                 // Given
@@ -596,6 +686,36 @@
 
                 // Then
                 result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Pull_Request_Id_Env_Var_Is_Not_Set_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", null);
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Pull_Request_Id_Env_Var_Is_Not_Set_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", null);
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
             }
 
             [Fact]
@@ -614,6 +734,36 @@
             }
 
             [Fact]
+            public void Should_Throw_If_Pull_Request_Id_Env_Var_Is_Empty_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", string.Empty);
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Pull_Request_Id_Env_Var_Is_Empty_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", string.Empty);
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
+            }
+
+            [Fact]
             public void Should_Throw_If_Pull_Request_Id_Env_Var_Is_WhiteSpace()
             {
                 // Given
@@ -626,6 +776,36 @@
 
                 // Then
                 result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Pull_Request_Id_Env_Var_Is_WhiteSpace_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", " ");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Pull_Request_Id_Env_Var_Is_WhiteSpace_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", " ");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
             }
 
             [Fact]
@@ -644,6 +824,36 @@
             }
 
             [Fact]
+            public void Should_Throw_If_Pull_Request_Id_Env_Var_Is_Not_Integer_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "foo");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Pull_Request_Id_Env_Var_Is_Not_Integer_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "foo");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
+            }
+
+            [Fact]
             public void Should_Throw_If_Pull_Request_Id_Is_Zero()
             {
                 // Given
@@ -656,6 +866,36 @@
 
                 // Then
                 result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Pull_Request_Id_Is_Zero_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "0");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Pull_Request_Id_Is_Zero_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "0");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", "foo");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
             }
 
             [Fact]
@@ -674,6 +914,36 @@
             }
 
             [Fact]
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_Not_Set_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", null);
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_System_Access_Token_Env_Var_Is_Not_Set_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", null);
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
+            }
+
+            [Fact]
             public void Should_Throw_If_System_Access_Token_Env_Var_Is_Empty()
             {
                 // Given
@@ -689,6 +959,36 @@
             }
 
             [Fact]
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_Empty_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", string.Empty);
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_System_Access_Token_Env_Var_Is_Empty_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", string.Empty);
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
+            }
+
+            [Fact]
             public void Should_Throw_If_System_Access_Token_Env_Var_Is_WhiteSpace()
             {
                 // Given
@@ -701,6 +1001,36 @@
 
                 // Then
                 result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_System_Access_Token_Env_Var_Is_WhiteSpace_And_Parameter_Is_True()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", " ");
+
+                // When
+                var result = Record.Exception(() => AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(true));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_System_Access_Token_Env_Var_Is_WhiteSpace_And_Parameter_Is_False()
+            {
+                // Given
+                Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "http://example.com");
+                Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTID", "42");
+                Environment.SetEnvironmentVariable("SYSTEM_ACCESSTOKEN", " ");
+
+                // When
+                var result = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(false);
+
+                // Then
+                result.ShouldBeNull();
             }
 
             [Fact]

--- a/src/Cake.AzureDevOps/AzureDevOpsAliases.PullRequest.cs
+++ b/src/Cake.AzureDevOps/AzureDevOpsAliases.PullRequest.cs
@@ -97,8 +97,8 @@
         /// Make sure the build has the 'Allow Scripts to access OAuth token' option enabled.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="throwExceptionIfPullRequestCouldNotBeFound">Value indicating whether an exception
-        /// should be thrown if pull request could not be found.</param>
+        /// <param name="throwException">Value indicating whether an exception
+        /// should be thrown if not running in Azure Pipelines or pull request could not be found.</param>
         /// <example>
         /// <para>Get a pull request:</para>
         /// <code>
@@ -109,13 +109,14 @@
         /// </code>
         /// </example>
         /// <returns>Description of the pull request.
-        /// Returns <c>null</c> if pull request could not be found and
-        /// <paramref name="throwExceptionIfPullRequestCouldNotBeFound"/> is set to <c>false</c>.</returns>
-        /// <exception cref="InvalidOperationException">If build is not running in Azure Pipelines,
-        /// build is not for a pull request or 'Allow Scripts to access OAuth token' option is not enabled
-        /// on the build definition.</exception>
-        /// <exception cref="AzureDevOpsPullRequestNotFoundException">If pull request could not be found and
-        /// <paramref name="throwExceptionIfPullRequestCouldNotBeFound"/> is set to <c>true</c>.</exception>
+        /// Returns <c>null</c> if pull request could not be found or if not running in an Azure Pipelines build and
+        /// <paramref name="throwException"/> is set to <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">If <paramref name="throwException"/>
+        /// is set to <c>true</c> and build is not running in Azure Pipelines, build is not for a pull request or
+        /// 'Allow Scripts to access OAuth token' option is not enabled on the build definition.</exception>
+        /// <exception cref="AzureDevOpsPullRequestNotFoundException">If
+        /// <paramref name="throwException"/> is set to <c>true</c> and pull request
+        /// could not be found.</exception>
         [CakeMethodAlias]
         [CakeAliasCategory("Pull Request")]
         [CakeNamespaceImport("Cake.AzureDevOps.Repos")]
@@ -123,18 +124,18 @@
         [CakeNamespaceImport("Cake.AzureDevOps.Repos.PullRequest.CommentThread")]
         public static AzureDevOpsPullRequest AzureDevOpsPullRequestUsingAzurePipelinesOAuthToken(
             this ICakeContext context,
-            bool throwExceptionIfPullRequestCouldNotBeFound)
+            bool throwException)
         {
             context.NotNull(nameof(context));
 
-            var settings = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(throwExceptionIfPullRequestCouldNotBeFound);
+            var settings = AzureDevOpsPullRequestSettings.UsingAzurePipelinesOAuthToken(throwException);
 
             if (settings == null)
             {
                 return null;
             }
 
-            settings.ThrowExceptionIfPullRequestCouldNotBeFound = throwExceptionIfPullRequestCouldNotBeFound;
+            settings.ThrowExceptionIfPullRequestCouldNotBeFound = throwException;
 
             return AzureDevOpsPullRequest(context, settings);
         }

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequestSettings.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequestSettings.cs
@@ -124,7 +124,19 @@
                 return null;
             }
 
-            return new AzureDevOpsPullRequestSettings(new AzureDevOpsOAuthCredentials(accessToken));
+            try
+            {
+                return new AzureDevOpsPullRequestSettings(new AzureDevOpsOAuthCredentials(accessToken));
+            }
+            catch (InvalidOperationException)
+            {
+                if (!throwExceptionIfVariablesDontExist)
+                {
+                    return null;
+                }
+
+                throw;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Don't throw an exception in `AzureDevOpsPullRequestUsingAzurePipelinesOAuthToken` if not running in an Azure Pipelines pull request build if `throwException` is set to `false`.

The parameter `throwExceptionIfPullRequestCouldNotBeFound` has been renamed to `throwException` to make it more obvious that it will also handle exceptions if Azure Pipelines variables are not available. 

Fixes #435 