### PR TITLE
Enable Renovate for test projects

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>cake-contrib/renovate-presets:cake-recipe"
+    "github>cake-contrib/renovate-presets:cake-recipe",
+    "includeNodeModules"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
`renovate-presets:cake-recipe` (or actually `config:recommended`) includes `:ignoreModulesAndTests` which excludes beside others test folder. By including `:includeNodeModules` it will reset `ignorePaths`.